### PR TITLE
Update base_email template to be compatible with mjml v4

### DIFF
--- a/birdsong/templates/birdsong/mail/base_email.html
+++ b/birdsong/templates/birdsong/mail/base_email.html
@@ -7,10 +7,10 @@
         {% endblock email_head %}
     </mj-head>
     <mj-body>
-    <mj-container>
+    <mj-section>
         {% block email_body %}
         {% endblock email_body %}
-    </mj-container>
+    </mj-section>
     </mj-body>
     </mjml>
 {% endmjml %}

--- a/birdsong/templates/birdsong/mail/base_email.html
+++ b/birdsong/templates/birdsong/mail/base_email.html
@@ -7,10 +7,8 @@
         {% endblock email_head %}
     </mj-head>
     <mj-body>
-    <mj-section>
         {% block email_body %}
         {% endblock email_body %}
-    </mj-section>
     </mj-body>
     </mjml>
 {% endmjml %}


### PR DESCRIPTION
Removed mj-container from the base_email template which was throwing a breaking error Runtime error.

Error: RuntimeError: MJML stderr is not empty: mjml-migrate is deprecated and will be removed in mjml 5.

Based on the mjml docs, mj-sections are added directly to mj-body now without the container. Source: https://documentation.mjml.io/#getting-started.
