### PR TITLE
Fix unsusbcribe email template example from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,7 +221,11 @@ Included in birdsong is a basic way for contacts to unsubscribe, just include th
         </mj-column>
     </mj-section>
     <mj-section>
-        Click <a href="{{ site.full_url }}{% url 'birdsong:unsubscribe' contact.id %}">here</a> to unsubscribe.
+        <mj-column>
+            <mj-text align="center">
+                Click <a href="{{ site.full_url }}{% url 'birdsong:unsubscribe' contact.id %}">here</a> to unsubscribe.
+            </mj-text>
+        </mj-column>
     </mj-section>
     {% endblock email_body %}
 


### PR DESCRIPTION
As I understand it from MJML doc, `<a>` tags cannot be used directly inside a `<mj-section>` tag.
Hence the addition of `<mj-column>` and `<mj-text>` tags in order for MJML to be able to process the file.