### PR TITLE
Fixes #31: Introduced a better way to preview and test campaigns …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,11 +147,11 @@ You can override the default ``Contact`` model by setting an option on the admin
 
 .. code-block:: python
 
-    # You may want to extend the test contact
+    # You may want to redefine the test contact (used in previews) with your new ExtendedContact fields
     BIRDSONG_TEST_CONTACT = {
         'first_name': 'Wagtail',
         'last_name': 'Birdsong',
-        'email': 'birdsong@example.com',
+        'email': 'wagtail.birdsong@example.com',
         'location': 'us',
     }
 

--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,19 @@ You can override the default ``Contact`` model by setting an option on the admin
         list_diplay = ('email', 'first_name', 'last_name', 'location')
 
 
+``base.py``
+
+.. code-block:: python
+
+    # You may want to extend the test contact
+    BIRDSONG_TEST_CONTACT = {
+        'first_name': 'Wagtail',
+        'last_name': 'Birdsong',
+        'email': 'birdsong@example.com',
+        'location': 'us',
+    }
+
+
 Filtering on contact properties
 ===============================
 

--- a/birdsong/conf.py
+++ b/birdsong/conf.py
@@ -1,0 +1,3 @@
+from django.conf import settings
+
+BIRDSONG_TEST_CONTACT = getattr(settings, 'BIRDSONG_TEST_CONTACT', { 'email': 'wagtail.birdsong@example.com' })

--- a/birdsong/options.py
+++ b/birdsong/options.py
@@ -11,6 +11,8 @@ from .models import CampaignStatus, Contact
 from .views import actions
 from .views import editor as editor_views
 
+from birdsong.conf import BIRDSONG_TEST_CONTACT
+
 BIRDSONG_DEFAULT_BACKEND = 'birdsong.backends.smtp.SMTPEmailBackend'
 
 
@@ -105,7 +107,7 @@ class CampaignAdmin(ModelAdmin):
 
     def preview(self, request, instance_pk):
         campaign = self.model.objects.get(pk=instance_pk)
-        contact = self.contact_class.objects.first()
+        contact = self.contact_class(**BIRDSONG_TEST_CONTACT)
         return editor_views.preview(request, campaign, contact)
 
     def confirm_send(self, request, instance_pk):
@@ -137,7 +139,7 @@ class CampaignAdmin(ModelAdmin):
         contacts = self.get_contacts_send_to(request)
         return actions.send_campaign(self.backend, request, campaign, contacts)
 
-    def create_contact_form(self, data=None):
+    def create_contact_form(self, data=BIRDSONG_TEST_CONTACT):
         ContactForm = modelform_factory(self.contact_class, exclude=['id'])
         if data:
             return ContactForm(data)

--- a/birdsong/views/editor.py
+++ b/birdsong/views/editor.py
@@ -1,3 +1,4 @@
+from birdsong.conf import BIRDSONG_TEST_CONTACT
 from django.http.response import JsonResponse
 from django.shortcuts import render
 from django.template.loader import render_to_string
@@ -65,9 +66,7 @@ def ajax_preview(request, view):
     form = FormClass(request.POST)
     if form.is_valid():
         campaign = form.save(commit=False)
-        contact_class = view.model_admin.contact_class
-        # FIXME won't work with no contacts
-        test_contact = contact_class.objects.first()
+        test_contact = view.model_admin.contact_class(**BIRDSONG_TEST_CONTACT)
         content = render_to_string(
             campaign.get_template(request),
             campaign.get_context(request, test_contact)

--- a/birdsong/views/editor.py
+++ b/birdsong/views/editor.py
@@ -42,12 +42,7 @@ class InspectCampaign(InspectView):
         self.contact_class = model_admin.contact_class
 
     def get_context_data(self, **kwargs):
-        first_receipt = self.instance.receipts.first()
-        if first_receipt:
-            preview_contact = self.contact_class.objects.filter(
-                pk=first_receipt.pk).first()
-        else:
-            preview_contact = None
+        preview_contact = self.contact_class(**BIRDSONG_TEST_CONTACT)
         # Should this be frozen? Changes to templates will change old campaigns
         preview = render_to_string(
             self.instance.get_template(self.request),


### PR DESCRIPTION
…  using a configurable (optional) Test Contact

- [x] Alleviates the necessity to have a contact record in the database for some of Birdsong's functionality to work out-of-the-box.
- [x] Prevents accidental unsubscribing of the first contact in the database when using unsubscribe links in previews.
- [x] Works with Send Test functionality.
- [x] Works without any modifications even in projects with Extended Contact models.
- [x] Introduces a new optional `BIRDSONG_TEST_CONTACT` setting that can be used to further extend and control the preview / send test experience.