### PR TITLE
Add support for plaintext alternatives in campaigns

### DIFF
--- a/birdsong/models.py
+++ b/birdsong/models.py
@@ -76,6 +76,9 @@ class Campaign(models.Model):
     def get_template(self, request):
         return "mail/%s.html" % (camelcase_to_underscore(self.__class__.__name__))
 
+    def get_text_template(self, request):
+        return "mail/%s.txt" % (camelcase_to_underscore(self.__class__.__name__))
+
     def get_context(self, request, contact):
         site = Site.find_for_request(request)
         return {

--- a/birdsong/utils.py
+++ b/birdsong/utils.py
@@ -13,8 +13,12 @@ def send_mass_html_mail(email_data, fail_silently=False, auth_user=None,
     )
 
     def _email_from_dict(data):
+        if 'html_body' not in data:
+            html_body = data.pop('body')
+        else:
+            html_body = data.pop('html_body')
         msg = EmailMultiAlternatives(connection=connection, **data)
-        msg.attach_alternative(data['body'], "text/html")
+        msg.attach_alternative(html_body, "text/html")
         return msg
 
     messages = [_email_from_dict(d) for d in email_data]


### PR DESCRIPTION
Fixes #50 

Adds `Campaign.get_text_template()` that defaults to the same template as `get_template()`, but with a `.txt` extension.
If the text template is found, it will be used to render a plaintext version of the mailing. If it isn’t, the mail will still be sent, but no plaintext part will be included. This means that mails without a text counterpart will be roughly 2 times lighter, and that text clients won’t display HTML content as text.